### PR TITLE
[RFC] Can create instance of bundle from array notation

### DIFF
--- a/BundleDependenciesResolver.php
+++ b/BundleDependenciesResolver.php
@@ -187,8 +187,15 @@ trait BundleDependenciesResolver
      */
     private function getBundleDefinitionInstance($bundle)
     {
-        return is_object($bundle)
-            ? $bundle
-            : new $bundle($this);
+        if (is_object($bundle)) {
+            return $bundle;
+        }
+
+        if (is_array($bundle)) {
+            $reflection = new \ReflectionClass($bundle[0]);
+            return $reflection->newInstanceArgs($bundle[1]);
+        }
+
+        return new $bundle($this);
     }
 }

--- a/BundleDependenciesResolver.php
+++ b/BundleDependenciesResolver.php
@@ -171,9 +171,15 @@ trait BundleDependenciesResolver
      */
     private function getBundleDefinitionNamespace($bundle)
     {
-        return ltrim(is_object($bundle)
-            ? get_class($bundle)
-            : $bundle, ' \\');
+        if (is_object($bundle)) {
+            $class = get_class($bundle);
+        } elseif (is_array($bundle)) {
+            $class = $bundle[0];
+        } else {
+            $class = $bundle;
+        }
+
+        return ltrim($class, ' \\');
     }
 
     /**

--- a/Tests/Bundle8.php
+++ b/Tests/Bundle8.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the php-formatter package
+ *
+ * Copyright (c) 2014 Marc Morera
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\SymfonyBundleDependencies\Tests;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;
+
+/**
+ * Class Bundle8.
+ */
+class Bundle8 implements DependentBundleInterface
+{
+    /**
+     * Create instance of current bundle, and return dependent bundle namespaces.
+     *
+     * @return array Bundle instances
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        return [
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle6',
+            ['Mmoreram\SymfonyBundleDependencies\Tests\Bundle5', ['B']],
+        ];
+    }
+}

--- a/Tests/BundleDependenciesResolverAware.php
+++ b/Tests/BundleDependenciesResolverAware.php
@@ -66,4 +66,25 @@ class BundleDependenciesResolverAware
             $bundles
         );
     }
+
+
+
+    /**
+     * Get bundle instances.
+     *
+     * @param KernelInterface $kernel Kernel
+     *
+     * @return Bundle[] Bundles
+     */
+    public function getInstancesTest3(KernelInterface $kernel)
+    {
+        $bundles = [
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle8',
+        ];
+
+        return $this->getBundleInstances(
+            $kernel,
+            $bundles
+        );
+    }
 }

--- a/Tests/BundleDependenciesResolverTest.php
+++ b/Tests/BundleDependenciesResolverTest.php
@@ -82,4 +82,39 @@ class BundleDependenciesResolverTest extends PHPUnit_Framework_TestCase
             $bundles[2]
         );
     }
+
+    /**
+     * Test resolver3.
+     */
+    public function testResolver3()
+    {
+        $kernel = $this->prophesize('Symfony\Component\HttpKernel\KernelInterface');
+        $bundleDependenciesResolver = new BundleDependenciesResolverAware();
+        $bundles = $bundleDependenciesResolver->getInstancesTest3($kernel->reveal());
+
+        $this->assertInstanceOf(
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle1',
+            $bundles[0]
+        );
+
+        $this->assertInstanceOf(
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle2',
+            $bundles[1]
+        );
+
+        $this->assertInstanceOf(
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle5',
+            $bundles[2]
+        );
+
+        $this->assertInstanceOf(
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle6',
+            $bundles[3]
+        );
+
+        $this->assertInstanceOf(
+            'Mmoreram\SymfonyBundleDependencies\Tests\Bundle8',
+            $bundles[4]
+        );
+    }
 }


### PR DESCRIPTION
This is to follow up on https://github.com/mmoreram/symfony-bundle-dependencies/issues/8#issuecomment-187437962 by @Toflar.

The idea is that a bundle can also return a cacheable version of a bundle with constructor arguments, assuming it contains only scalar values. Example:

``` php
use Mmoreram\SymfonyBundleDependencies\DependentBundleInterface;

/**
 * My Bundle
 */
class MyBundle implements DependentBundleInterface
{
    /**
     * Create instance of current bundle, and return dependent bundle namespaces
     *
     * @return array Bundle instances
     */
    public static function getBundleDependencies(KernelInterface $kernel)
    {
        return [
            ['\Even\Another\Bundle\EvenAnotherBundle', ['foo', 'bar', $kernel->getRootDir()]]
        ];
    }
}
```

Please let me know your general thoughts. I would later add documentation and tests if you like the idea.

/cc @leofeyer @ausi @discordier
